### PR TITLE
Make netstatus_icon_set_tooltips_enabled() work

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
 * Fixed battery alarm when measurement of current is missing.
 * Fixed spelling errors on "allow to" in plugins descriptions, and "GTK2+" to
     more correct "GTK+".
+* Made netstatus_icon_set_tooltips_enabled() work.
 
 0.10.0
 -------------------------------------------------------------------------

--- a/plugins/netstatus/netstatus-icon.c
+++ b/plugins/netstatus/netstatus-icon.c
@@ -386,7 +386,8 @@ netstatus_icon_name_changed (NetstatusIface *iface __attribute__((unused)),
       tip = _("Network Connection");
     }
 
-  gtk_widget_set_tooltip_text(GTK_WIDGET (icon), tip);
+  if (icon->priv->tooltips_enabled)
+    gtk_widget_set_tooltip_text(GTK_WIDGET(icon), tip);
 
   g_free (freeme);
 }
@@ -898,6 +899,7 @@ netstatus_icon_instance_init (NetstatusIcon      *icon,
   icon->priv->orientation      = GTK_ORIENTATION_HORIZONTAL;
   icon->priv->size             = 0;
   icon->priv->state_changed_id = 0;
+  icon->priv->tooltips_enabled = TRUE;
 
   gtk_box_set_spacing (GTK_BOX (icon), 3);
 
@@ -1096,7 +1098,10 @@ netstatus_icon_set_tooltips_enabled (NetstatusIcon *icon,
     {
       icon->priv->tooltips_enabled = enabled;
 
-      g_object_notify (G_OBJECT (icon), "tooltips-enabled");
+      if (!icon->priv->tooltips_enabled)
+        gtk_widget_set_has_tooltip(GTK_WIDGET(icon), FALSE);
+
+      /* g_object_notify (G_OBJECT (icon), "tooltips-enabled"); */
     }
 }
 


### PR DESCRIPTION
Newly created icons have tooltips by default. Disabling the tooltips with netstatus_icon_set_tooltips_enabled() had no effect so far.

While the icon in the panel bar should show the tooltip, the icon displayed in the dialog should not display it, but even though disabled, it has no effect.

Icons still have tooltips by default, which is now set explicitly at initialization. netstatus_icon_set_tooltips_enabled() will now actually disable the tooltips and in netstatus_icon_name_changed() the tooltips will only be set if enabled.